### PR TITLE
Servo Motor mode is now set to "instantaneous"

### DIFF
--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/motor_model_servo.hpp
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/motor_model_servo.hpp
@@ -119,6 +119,7 @@ class MotorModelServo : public MotorModel {
       switch (mode_) {
         case (ControlMode::kPosition): {
           joint_controller_->SetPositionPID(joint_->GetScopedName(), pid_);
+          //joint_controller_ -> SetJointPosition(joint_, 0.0);
           break;
         }
         case (ControlMode::kVelocity): {
@@ -164,8 +165,9 @@ class MotorModelServo : public MotorModel {
     switch (mode_) {
       case (ControlMode::kPosition): {
         if (!std::isnan(ref_motor_rot_pos_)) {
-          joint_controller_->SetPositionTarget(joint_->GetScopedName(),
-                                               turning_direction_ * ref_motor_rot_pos_);
+          // joint_controller_->SetPositionTarget(joint_->GetScopedName(),
+          //                                      turning_direction_ * ref_motor_rot_pos_);
+          joint_controller_->SetJointPosition(joint_ ->GetScopedName(), turning_direction_ * ref_motor_rot_pos_);
           joint_controller_->Update();
         }
         break;


### PR DESCRIPTION
Meaning: If one commands an joint angle - the joints directly rotate there without an PID between.